### PR TITLE
Upgrade version of `golangci-lint`, enable new linters and address issues found

### DIFF
--- a/.devcontainer/.custom-gcl.template.yml
+++ b/.devcontainer/.custom-gcl.template.yml
@@ -1,4 +1,4 @@
-version: v2.6.2
+version: v2.11.4
 name: golangci-lint-custom
 destination: $TOOL_DEST
 plugins:

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -173,7 +173,7 @@ if should-install "$TOOL_DEST/golangci-lint"; then
     write-info "Installing golangci-lint"
     # golangci-lint is provided by base image if in devcontainer
     # this command copied from there
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 fi
 
 if should-install "$TOOL_DEST/golangci-lint-custom"; then

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters:
     - noinlineerr
     - noctx
     - nolintlint
+    - nonamedreturns
     - paralleltest
     - perfsprint
     - prealloc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,11 @@ linters:
     - exhaustive
     - exptostd
     - fatcontext
+    - forcetypeassert
     - funlen
     - ginkgolinter
     - gocheckcompilerdirectives
+    - gochecknoinits
     - gochecksumtype
     - gocognit
     - goconst
@@ -47,6 +49,7 @@ linters:
     - nilnesserr
     - nilnil
     - nlreturn
+    - noinlineerr
     - noctx
     - nolintlint
     - paralleltest
@@ -58,6 +61,7 @@ linters:
     - recvcheck
     - revive
     - rowserrcheck
+    - sloglint
     - spancheck
     - sqlclosecheck
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,13 +13,16 @@ linters:
     - dupl
     - dupword
     - durationcheck
+    - embeddedstructfieldcheck
     - errchkjson
     - errname
     - errorlint
     - exhaustive
     - exptostd
     - fatcontext
+    - forbidigo
     - forcetypeassert
+    - funcorder
     - funlen
     - ginkgolinter
     - gocheckcompilerdirectives
@@ -36,6 +39,7 @@ linters:
     - iface
     - inamedparam
     - intrange
+    - iotamixing
     - loggercheck
     - maintidx
     - makezero
@@ -84,6 +88,10 @@ linters:
   settings:
     cyclop:
       max-complexity: 10
+    forbidigo:
+      forbid:
+        - pattern: 'fmt\.Errorf'
+          msg: "use eris.Wrap, eris.Wrapf, or eris.New instead of fmt.Errorf"
     exhaustive:
       default-signifies-exhaustive: true
     funlen:

--- a/docs/superpowers/plans/2026-04-15-upgrade-linters.md
+++ b/docs/superpowers/plans/2026-04-15-upgrade-linters.md
@@ -1,0 +1,465 @@
+# Upgrade golangci-lint and Adopt New Linters — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade golangci-lint from v2.6.2 to v2.11.4 and adopt high-value new linters.
+
+**Architecture:** Bump the version in the custom build template and install script, rebuild, fix findings from existing linters, then trial and adopt new linters one at a time.
+
+**Tech Stack:** golangci-lint v2.11.4, Go, custom golangci-lint build with nilaway plugin
+
+---
+
+### Task 1: Bump golangci-lint version
+
+**Files:**
+- Modify: `.devcontainer/.custom-gcl.template.yml`
+- Modify: `.devcontainer/install-dependencies.sh:~178` (golangci-lint install version)
+
+- [ ] **Step 1: Update the custom build template version**
+
+In `.devcontainer/.custom-gcl.template.yml`, change line 1:
+
+```yaml
+version: v2.11.4
+```
+
+(was `v2.6.2`)
+
+- [ ] **Step 2: Update the standard golangci-lint install version**
+
+In `.devcontainer/install-dependencies.sh`, find the line:
+
+```bash
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
+```
+
+Change to:
+
+```bash
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+```
+
+- [ ] **Step 3: Rebuild the custom binary**
+
+```bash
+cd /workspaces/task-graph
+.devcontainer/install-dependencies.sh --skip-installed
+```
+
+This will skip tools that are already installed except golangci-lint-custom
+(since the template changed). If it skips golangci-lint-custom too, force
+rebuild:
+
+```bash
+rm -f /usr/local/bin/golangci-lint-custom
+.devcontainer/install-dependencies.sh --skip-installed
+```
+
+- [ ] **Step 4: Verify the new version**
+
+```bash
+golangci-lint-custom version
+```
+
+Expected: version string containing `v2.11.4`
+
+- [ ] **Step 5: Commit version bump**
+
+```bash
+git add .devcontainer/.custom-gcl.template.yml .devcontainer/install-dependencies.sh
+git commit -m "chore: bump golangci-lint from v2.6.2 to v2.11.4"
+```
+
+---
+
+### Task 2: Fix findings from existing linters after upgrade
+
+**Files:**
+- Modify: `.golangci.yml` (if new revive rules need disabling)
+- Modify: various source files (to fix legitimate findings)
+
+- [ ] **Step 1: Run the linter and capture findings**
+
+```bash
+task lint 2>&1 | head -200
+```
+
+Review each finding. Categorise as:
+- **Legitimate fix** → fix the code
+- **False positive / too noisy** → suppress with `nolint` + explanation, or
+  disable the specific rule
+
+- [ ] **Step 2: Fix legitimate findings in source files**
+
+Apply fixes to each flagged file. For autofixable issues:
+
+```bash
+golangci-lint-custom run --fix --verbose
+```
+
+Review the autofixed changes before proceeding.
+
+- [ ] **Step 3: Disable noisy new revive rules if needed**
+
+If any new revive rules are too noisy, add them to the `revive.rules` section
+in `.golangci.yml` following the existing pattern:
+
+```yaml
+    revive:
+      rules:
+        - name: <noisy-rule-name>
+          disabled: true
+```
+
+- [ ] **Step 4: Verify clean lint**
+
+```bash
+task lint
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Run tests to confirm no regressions**
+
+```bash
+go test ./...
+```
+
+Expected: all tests pass. If golden files need updating:
+
+```bash
+go test ./... -update
+```
+
+Then review the diffs in `testdata/` directories before accepting.
+
+- [ ] **Step 6: Commit fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve lint findings from golangci-lint v2.11.4 upgrade"
+```
+
+---
+
+### Task 3: Trial and adopt Tier 1 linters
+
+**Files:**
+- Modify: `.golangci.yml` (add to `enable` list)
+- Modify: `internal/cmd/cli.go:158` (fix inline error handling)
+
+Trial each Tier 1 linter. For each: add to config, run lint, assess, keep or
+remove.
+
+- [ ] **Step 1: Add `noinlineerr` to the enable list**
+
+In `.golangci.yml`, add `noinlineerr` to the `linters.enable` list
+(alphabetical order, between `nlreturn` and `noctx`):
+
+```yaml
+    - noinlineerr
+```
+
+- [ ] **Step 2: Run lint to find inline error patterns**
+
+```bash
+task lint
+```
+
+Expected: one finding in `internal/cmd/cli.go:158`:
+
+```go
+if err := c.loadConfigFile(cfg); err != nil {
+```
+
+- [ ] **Step 3: Fix the inline error pattern**
+
+In `internal/cmd/cli.go`, change:
+
+```go
+	if c.Config != "" {
+		if err := c.loadConfigFile(cfg); err != nil {
+			return nil, err
+		}
+	}
+```
+
+To:
+
+```go
+	if c.Config != "" {
+		err := c.loadConfigFile(cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+```
+
+- [ ] **Step 4: Add `gochecknoinits` to the enable list**
+
+In `.golangci.yml`, add `gochecknoinits` to the `linters.enable` list
+(alphabetical order, between `gocheckcompilerdirectives` and
+`gochecksumtype`):
+
+```yaml
+    - gochecknoinits
+```
+
+- [ ] **Step 5: Run lint to verify gochecknoinits is clean**
+
+```bash
+task lint
+```
+
+Expected: no findings (the codebase has no `init()` functions).
+
+- [ ] **Step 6: Add `forcetypeassert` to the enable list**
+
+In `.golangci.yml`, add `forcetypeassert` to the `linters.enable` list
+(alphabetical order, between `fatcontext` and `funlen`):
+
+```yaml
+    - forcetypeassert
+```
+
+- [ ] **Step 7: Run lint to verify forcetypeassert is clean**
+
+```bash
+task lint
+```
+
+Expected: no findings (the one type assertion in the codebase already uses
+comma-ok form at `internal/graphviz/node_properties.go:59`).
+
+- [ ] **Step 8: Add `sloglint` to the enable list**
+
+In `.golangci.yml`, add `sloglint` to the `linters.enable` list (alphabetical
+order, between `rowserrcheck` and `spancheck`):
+
+```yaml
+    - sloglint
+```
+
+- [ ] **Step 9: Run lint to assess sloglint findings**
+
+```bash
+task lint
+```
+
+Review any findings. The project uses `log/slog` in `internal/cmd/cli.go` and
+`internal/cmd/context.go`. If findings are legitimate, fix them. If sloglint
+is too noisy for this codebase's usage pattern, remove it from the enable list.
+
+- [ ] **Step 10: Verify all tests still pass**
+
+```bash
+go test ./...
+```
+
+- [ ] **Step 11: Commit Tier 1 linters**
+
+```bash
+git add -A
+git commit -m "chore: adopt noinlineerr, gochecknoinits, forcetypeassert, sloglint linters"
+```
+
+Adjust the commit message to list only the linters that were actually adopted
+(drop any that were removed during trial).
+
+---
+
+### Task 4: Trial and adopt Tier 2 linters
+
+**Files:**
+- Modify: `.golangci.yml` (add to `enable` list, add settings)
+
+Trial each Tier 2 linter. For each: add to config, run lint, assess, keep or
+remove.
+
+- [ ] **Step 1: Add `iotamixing` to the enable list**
+
+In `.golangci.yml`, add `iotamixing` to the `linters.enable` list
+(alphabetical order, between `intrange` and `loggercheck`):
+
+```yaml
+    - iotamixing
+```
+
+- [ ] **Step 2: Run lint to verify iotamixing is clean**
+
+```bash
+task lint
+```
+
+Expected: no findings (the codebase has no iota usage).
+
+- [ ] **Step 3: Add `funcorder` to the enable list**
+
+In `.golangci.yml`, add `funcorder` to the `linters.enable` list
+(alphabetical order, between `fatcontext`/`forcetypeassert` and `funlen`):
+
+```yaml
+    - funcorder
+```
+
+- [ ] **Step 4: Run lint to assess funcorder findings**
+
+```bash
+task lint
+```
+
+If many files need reordering, the linter doesn't match existing conventions —
+remove it. If only a few files need adjustments or it's clean, keep it.
+
+- [ ] **Step 5: Fix funcorder findings or remove if too noisy**
+
+If keeping: reorder functions in flagged files to match the expected order
+(constructors first, then exported methods, then unexported methods).
+
+If removing: delete `funcorder` from the enable list.
+
+- [ ] **Step 6: Add `forbidigo` with `fmt.Errorf` rule**
+
+In `.golangci.yml`, add `forbidigo` to the `linters.enable` list
+(alphabetical order, between `fatcontext`/`forcetypeassert`/`funcorder` and
+`funlen`):
+
+```yaml
+    - forbidigo
+```
+
+And add settings:
+
+```yaml
+    forbidigo:
+      forbid:
+        - pattern: 'fmt\.Errorf'
+          msg: "use eris.Wrap, eris.Wrapf, or eris.New instead of fmt.Errorf"
+```
+
+- [ ] **Step 7: Run lint to verify forbidigo is clean**
+
+```bash
+task lint
+```
+
+Expected: no findings (the codebase does not use `fmt.Errorf`). This linter
+serves as prevention — enforcing the eris convention going forward.
+
+- [ ] **Step 8: Add `embeddedstructfieldcheck` to the enable list**
+
+In `.golangci.yml`, add `embeddedstructfieldcheck` to the `linters.enable`
+list (alphabetical order, between `dupword` and `errchkjson`):
+
+```yaml
+    - embeddedstructfieldcheck
+```
+
+- [ ] **Step 9: Run lint to assess embeddedstructfieldcheck findings**
+
+```bash
+task lint
+```
+
+Three structs have embedded types:
+- `internal/graphviz/node_properties.go`: `nodeProperties` embeds `properties`
+- `internal/graphviz/edge_properties.go`: `edgeProperties` embeds `properties`
+- `internal/graph/node.go`: `Node` embeds `NodeID`
+
+If the linter flags them, check whether the embedded field is already at the
+top with a blank line. Fix if easy; remove linter if it causes too many changes
+or conflicts with existing style.
+
+- [ ] **Step 10: Verify all tests still pass**
+
+```bash
+go test ./...
+```
+
+- [ ] **Step 11: Commit Tier 2 linters**
+
+```bash
+git add -A
+git commit -m "chore: adopt iotamixing, funcorder, forbidigo, embeddedstructfieldcheck linters"
+```
+
+Adjust the commit message to list only the linters that were actually adopted.
+
+---
+
+### Task 5: Trial Tier 3 linter
+
+**Files:**
+- Modify: `.golangci.yml` (add to `enable` list)
+
+- [ ] **Step 1: Add `nonamedreturns` to the enable list**
+
+In `.golangci.yml`, add `nonamedreturns` to the `linters.enable` list
+(alphabetical order, between `nolintlint` and `paralleltest`):
+
+```yaml
+    - nonamedreturns
+```
+
+- [ ] **Step 2: Run lint to verify nonamedreturns is clean**
+
+```bash
+task lint
+```
+
+Expected: no findings (the codebase has no named returns).
+
+- [ ] **Step 3: Commit if adopted**
+
+```bash
+git add .golangci.yml
+git commit -m "chore: adopt nonamedreturns linter"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run full CI**
+
+```bash
+task ci
+```
+
+Expected: build, tests, lint, and SBOM generation all pass.
+
+- [ ] **Step 2: Update golden files if needed**
+
+If any test failures are due to golden file changes:
+
+```bash
+go test ./... -update
+```
+
+Review the diffs in `testdata/` directories. Only commit if the changes are
+expected (e.g., output format changes from linter upgrades don't affect golden
+files in this project, but test changes from code fixes might).
+
+```bash
+git add -A
+git commit -m "test: update golden files after linter upgrade"
+```
+
+- [ ] **Step 3: Run full CI one more time**
+
+```bash
+task ci
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Review the full diff**
+
+```bash
+git --no-pager log --oneline main..HEAD
+git --no-pager diff main..HEAD --stat
+```
+
+Confirm the change is reasonable in scope. If the diff is very large, consider
+whether the commits are well-structured for review.

--- a/docs/superpowers/specs/2026-04-15-upgrade-linters-design.md
+++ b/docs/superpowers/specs/2026-04-15-upgrade-linters-design.md
@@ -1,0 +1,161 @@
+# Upgrade golangci-lint and Adopt New Linters
+
+**Date**: 2026-04-15
+**Status**: Draft
+
+## Summary
+
+Upgrade the custom golangci-lint build from v2.6.2 to v2.11.4 and adopt
+high-value new linters that have been added since v2.6.2. Each candidate linter
+is trial-run against the codebase; only those with a good signal-to-noise ratio
+are included.
+
+## Context
+
+The project uses a custom golangci-lint build (with nilaway plugin) pinned at
+v2.6.2. The latest stable release is v2.11.4. Since v2.6.2, golangci-lint has
+added several new linters and existing linters have gained significant new rules
+and features.
+
+The project already enables 74 linters with a strict configuration. The goal is
+to stay current, catch more bugs, and enforce more consistency — while keeping
+false positives manageable. A handful of `nolint` suppressions are acceptable
+where the linter's overall value justifies them.
+
+## Version Upgrade: v2.6.2 → v2.11.4
+
+### File changes
+
+- `.devcontainer/.custom-gcl.template.yml`: bump `version` from `v2.6.2` to
+  `v2.11.4`
+- Rebuild the custom binary via `install-dependencies.sh`
+
+### Existing linter changes surfaced by the upgrade
+
+Already-enabled linters have gained new rules and features that may produce new
+findings on existing code:
+
+| Linter | Key changes since v2.6.2 |
+|--------|--------------------------|
+| gosec | ~17 new rules (G113, G116–G123, G408, G602, G701–G707) |
+| revive | New rules: `package-naming`, `epoch-naming`, `use-slices-sort`, `enforce-switch-style`, `forbidden-call-in-wg-go`, `unnecessary-if`, `inefficient-map-lookup`, `time-date`, `unnecessary-format`, `use-fmt-print` |
+| staticcheck | 0.6.1 → 0.7.0 |
+| modernize | New analyzers: `stringscut`, `unsafefuncs` |
+| wsl_v5 | 5.3.0 → 5.6.0 (new `after-block` rule) |
+| errcheck | Excludes `crypto/rand.Read` by default |
+
+Since revive is configured with `enable-all-rules: true`, new revive rules are
+automatically enabled. If any new rule is too noisy, add a targeted
+`disabled: true` entry — same pattern as existing `add-constant`,
+`function-length`, and `unhandled-error` exclusions.
+
+Findings from existing linters are fixed (or suppressed with explanation) as
+part of the upgrade.
+
+## New Linters to Adopt
+
+Each candidate is trial-run against the codebase. Include only if the
+signal-to-noise ratio is good.
+
+### Tier 1 — High confidence
+
+**`noinlineerr`** (added v2.2.0) — Enforces split error handling style. Forbids
+`if err := f(); err != nil {` in favour of separate assignment and check.
+Autofix available. Matches the project's preferred style.
+
+**`gochecknoinits`** (pre-existing, not yet enabled) — Forbids `init()`
+functions. The codebase has zero today; this prevents them from creeping in.
+Zero-noise linter.
+
+**`forcetypeassert`** (pre-existing, not yet enabled) — Flags bare type
+assertions (`x.(T)`) that don't use the comma-ok form. Real bug finder — an
+unchecked type assertion is a panic waiting to happen.
+
+**`sloglint`** (pre-existing, not yet enabled) — Enforces consistent `log/slog`
+usage patterns (key naming style, argument structure). The project uses slog for
+CLI logging.
+
+### Tier 2 — Medium confidence (trial and decide)
+
+**`iotamixing`** (added v2.5.0) — Flags const blocks that mix iota with
+non-iota values. Fast, low noise.
+
+**`funcorder`** (added v2.1.0) — Enforces ordering of constructors,
+exported/unexported methods. May need config tuning. Adopt if it aligns with
+existing patterns; skip if it requires major reshuffling.
+
+**`forbidigo`** (pre-existing, not yet enabled) — Can be configured to forbid
+`fmt.Errorf`, upgrading the eris convention from documentation to enforcement.
+
+**`embeddedstructfieldcheck`** (added v2.2.0) — Embedded types at top of struct
+with a blank line separator. Adopt if the codebase already follows this pattern.
+
+### Tier 3 — Low confidence
+
+**`nonamedreturns`** (pre-existing, not yet enabled) — Forbids named returns.
+Trial and adopt only if the codebase doesn't currently use them.
+
+### Not adopting
+
+| Linter | Reason |
+|--------|--------|
+| `unqueryvet` | No SQL in the project |
+| `arangolint` | No ArangoDB |
+| `canonicalheader` | No net/http usage |
+| `nosprintfhostport` | No URL construction |
+| `musttag` | Already disabled as "extremely slow" |
+| `mnd` | Magic number detection is typically very noisy |
+| `exhaustruct` | Too noisy — requires initializing every struct field |
+| `ireturn` | Opinionated; would need many suppressions |
+| `testpackage` | Project deliberately uses same-package tests |
+| `lll` | Already covered by revive's `line-length-limit` |
+| `gochecknoglobals` | Existing globals are all effectively constants/caches |
+| `containedctx` | No `context.Context` stored in structs |
+| `varnamelen` | Settings configured but not enabled — likely evaluated and skipped previously |
+| `decorder` | Low value for this codebase size |
+
+## Implementation Strategy
+
+### Trial process for each candidate linter
+
+1. Temporarily add the linter to the `enable` list in `.golangci.yml`
+2. Run `task lint`
+3. Assess findings:
+   - **All clean or ≤3 legitimate findings** → adopt, fix findings
+   - **Findings that are all autofixable** → adopt, apply autofix, review result
+   - **Many findings but all legitimate** → adopt, fix as part of the PR
+   - **Noisy / many false positives** → skip, don't include in final config
+4. Move on to next candidate
+
+### Order of operations
+
+1. Bump version in `.custom-gcl.template.yml` → rebuild custom binary → run
+   `task lint` → fix findings from existing linters
+2. Trial Tier 1 linters one at a time (noinlineerr, gochecknoinits,
+   forcetypeassert, sloglint)
+3. Trial Tier 2 linters one at a time (iotamixing, funcorder, forbidigo,
+   embeddedstructfieldcheck)
+4. Trial Tier 3 if time permits (nonamedreturns)
+5. Run full CI (`task ci`) to confirm everything passes
+6. Update golden files if output format changed (`go test ./... -update`,
+   review diffs)
+
+### Files touched
+
+- `.devcontainer/.custom-gcl.template.yml` — version bump
+- `.golangci.yml` — add adopted linters to `enable` list, add settings entries
+  as needed, disable noisy new revive rules if necessary
+- Source files — fix legitimate findings, add `nolint` directives with
+  explanations where suppression is warranted
+
+### Risk and mitigation
+
+**Large diff from upgrade**: The v2.11.x upgrade may surface many new findings
+from existing linters, making the PR larger than expected. Mitigation: split
+into two commits within the same PR (upgrade + fix existing, then add new
+linters) to make review easier.
+
+**Nilaway plugin compatibility**: The custom build uses nilaway as a module
+plugin. The v2.11.4 custom build framework may require a compatible nilaway
+version. If the build fails, check for nilaway updates or pin a compatible
+version in `.custom-gcl.template.yml`.

--- a/docs/superpowers/specs/2026-04-15-upgrade-linters-design.md
+++ b/docs/superpowers/specs/2026-04-15-upgrade-linters-design.md
@@ -35,14 +35,14 @@ where the linter's overall value justifies them.
 Already-enabled linters have gained new rules and features that may produce new
 findings on existing code:
 
-| Linter | Key changes since v2.6.2 |
-|--------|--------------------------|
-| gosec | ~17 new rules (G113, G116–G123, G408, G602, G701–G707) |
-| revive | New rules: `package-naming`, `epoch-naming`, `use-slices-sort`, `enforce-switch-style`, `forbidden-call-in-wg-go`, `unnecessary-if`, `inefficient-map-lookup`, `time-date`, `unnecessary-format`, `use-fmt-print` |
-| staticcheck | 0.6.1 → 0.7.0 |
-| modernize | New analyzers: `stringscut`, `unsafefuncs` |
-| wsl_v5 | 5.3.0 → 5.6.0 (new `after-block` rule) |
-| errcheck | Excludes `crypto/rand.Read` by default |
+| Linter      | Key changes since v2.6.2                                                                                                                                                                                          |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| gosec       | ~17 new rules (G113, G116–G123, G408, G602, G701–G707)                                                                                                                                                            |
+| revive      | New rules: `package-naming`, `epoch-naming`, `use-slices-sort`, `enforce-switch-style`, `forbidden-call-in-wg-go`, `unnecessary-if`, `inefficient-map-lookup`, `time-date`, `unnecessary-format`, `use-fmt-print` |
+| staticcheck | 0.6.1 → 0.7.0                                                                                                                                                                                                     |
+| modernize   | New analyzers: `stringscut`, `unsafefuncs`                                                                                                                                                                        |
+| wsl_v5      | 5.3.0 → 5.6.0 (new `after-block` rule)                                                                                                                                                                            |
+| errcheck    | Excludes `crypto/rand.Read` by default                                                                                                                                                                            |
 
 Since revive is configured with `enable-all-rules: true`, new revive rules are
 automatically enabled. If any new rule is too noisy, add a targeted
@@ -97,22 +97,22 @@ Trial and adopt only if the codebase doesn't currently use them.
 
 ### Not adopting
 
-| Linter | Reason |
-|--------|--------|
-| `unqueryvet` | No SQL in the project |
-| `arangolint` | No ArangoDB |
-| `canonicalheader` | No net/http usage |
-| `nosprintfhostport` | No URL construction |
-| `musttag` | Already disabled as "extremely slow" |
-| `mnd` | Magic number detection is typically very noisy |
-| `exhaustruct` | Too noisy — requires initializing every struct field |
-| `ireturn` | Opinionated; would need many suppressions |
-| `testpackage` | Project deliberately uses same-package tests |
-| `lll` | Already covered by revive's `line-length-limit` |
-| `gochecknoglobals` | Existing globals are all effectively constants/caches |
-| `containedctx` | No `context.Context` stored in structs |
-| `varnamelen` | Settings configured but not enabled — likely evaluated and skipped previously |
-| `decorder` | Low value for this codebase size |
+| Linter              | Reason                                                                        |
+| ------------------- | ----------------------------------------------------------------------------- |
+| `unqueryvet`        | No SQL in the project                                                         |
+| `arangolint`        | No ArangoDB                                                                   |
+| `canonicalheader`   | No net/http usage                                                             |
+| `nosprintfhostport` | No URL construction                                                           |
+| `musttag`           | Already disabled as "extremely slow"                                          |
+| `mnd`               | Magic number detection is typically very noisy                                |
+| `exhaustruct`       | Too noisy — requires initializing every struct field                          |
+| `ireturn`           | Opinionated; would need many suppressions                                     |
+| `testpackage`       | Project deliberately uses same-package tests                                  |
+| `lll`               | Already covered by revive's `line-length-limit`                               |
+| `gochecknoglobals`  | Existing globals are all effectively constants/caches                         |
+| `containedctx`      | No `context.Context` stored in structs                                        |
+| `varnamelen`        | Settings configured but not enabled — likely evaluated and skipped previously |
+| `decorder`          | Low value for this codebase size                                              |
 
 ## Implementation Strategy
 

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -97,6 +97,75 @@ func (c *CLI) Run(
 	return nil
 }
 
+// CreateLogger builds a slog logger configured from the CLI flags.
+func (c *CLI) CreateLogger() *slog.Logger {
+	level := slog.LevelInfo
+	if c.Verbose {
+		level = slog.LevelDebug
+	}
+
+	opts := &console.HandlerOptions{
+		Level: level,
+	}
+	handler := console.NewHandler(os.Stderr, opts)
+
+	return slog.New(handler)
+}
+
+func (c *CLI) CreateConfig() (*config.Config, error) {
+	cfg := config.New()
+
+	if c.Config != "" {
+		err := c.loadConfigFile(cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c.applyConfigOverrides(cfg)
+
+	return cfg, nil
+}
+
+// ExportConfigToFile writes the effective configuration to the given file path.
+// The format is determined by the file extension (.yaml, .yml, or .json).
+func (c *CLI) ExportConfigToFile(cfg *config.Config) error {
+	if c.ExportConfig == "" {
+		return nil
+	}
+
+	ext := strings.ToLower(filepath.Ext(c.ExportConfig))
+
+	var (
+		data []byte
+		err  error
+	)
+
+	switch ext {
+	case ".yaml", ".yml":
+		data, err = yaml.Marshal(cfg)
+		if err != nil {
+			return eris.Wrapf(err, "failed to marshal config as YAML")
+		}
+
+	case ".json":
+		data, err = json.MarshalIndent(cfg, "", "  ")
+		if err != nil {
+			return eris.Wrapf(err, "failed to marshal config as JSON")
+		}
+
+	default:
+		return eris.Errorf("unsupported file extension for config export: %s", ext)
+	}
+
+	err = os.WriteFile(c.ExportConfig, data, 0o600)
+	if err != nil {
+		return eris.Wrapf(err, "failed to write config file: %s", c.ExportConfig)
+	}
+
+	return nil
+}
+
 func (c *CLI) resolveGraphType(flags *Flags) string {
 	graphType := c.GraphType
 	if graphType == "" {
@@ -135,36 +204,6 @@ func (c *CLI) renderImage(ctx context.Context, flags *Flags) error {
 	)
 
 	return nil
-}
-
-// CreateLogger builds a slog logger configured from the CLI flags.
-func (c *CLI) CreateLogger() *slog.Logger {
-	level := slog.LevelInfo
-	if c.Verbose {
-		level = slog.LevelDebug
-	}
-
-	opts := &console.HandlerOptions{
-		Level: level,
-	}
-	handler := console.NewHandler(os.Stderr, opts)
-
-	return slog.New(handler)
-}
-
-func (c *CLI) CreateConfig() (*config.Config, error) {
-	cfg := config.New()
-
-	if c.Config != "" {
-		err := c.loadConfigFile(cfg)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	c.applyConfigOverrides(cfg)
-
-	return cfg, nil
 }
 
 // applyConfigOverrides applies CLI flag overrides to the configuration.
@@ -250,45 +289,6 @@ func (c *CLI) loadConfigFile(cfg *config.Config) error {
 
 	if err != nil {
 		return eris.Wrapf(err, "failed to parse config file: %s", c.Config)
-	}
-
-	return nil
-}
-
-// ExportConfigToFile writes the effective configuration to the given file path.
-// The format is determined by the file extension (.yaml, .yml, or .json).
-func (c *CLI) ExportConfigToFile(cfg *config.Config) error {
-	if c.ExportConfig == "" {
-		return nil
-	}
-
-	ext := strings.ToLower(filepath.Ext(c.ExportConfig))
-
-	var (
-		data []byte
-		err  error
-	)
-
-	switch ext {
-	case ".yaml", ".yml":
-		data, err = yaml.Marshal(cfg)
-		if err != nil {
-			return eris.Wrapf(err, "failed to marshal config as YAML")
-		}
-
-	case ".json":
-		data, err = json.MarshalIndent(cfg, "", "  ")
-		if err != nil {
-			return eris.Wrapf(err, "failed to marshal config as JSON")
-		}
-
-	default:
-		return eris.Errorf("unsupported file extension for config export: %s", ext)
-	}
-
-	err = os.WriteFile(c.ExportConfig, data, 0o600)
-	if err != nil {
-		return eris.Wrapf(err, "failed to write config file: %s", c.ExportConfig)
 	}
 
 	return nil

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -88,7 +88,8 @@ func (c *CLI) Run(
 	)
 
 	if c.RenderImage != "" {
-		if err = c.renderImage(ctx, flags); err != nil {
+		err = c.renderImage(ctx, flags)
+		if err != nil {
 			return err
 		}
 	}
@@ -155,7 +156,8 @@ func (c *CLI) CreateConfig() (*config.Config, error) {
 	cfg := config.New()
 
 	if c.Config != "" {
-		if err := c.loadConfigFile(cfg); err != nil {
+		err := c.loadConfigFile(cfg)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -238,7 +240,8 @@ func (c *CLI) loadConfigFile(cfg *config.Config) error {
 		err = json.Unmarshal(raw, cfg)
 	default:
 		// Attempt YAML first, then JSON, for unknown extensions.
-		if yamlErr := yaml.Unmarshal(raw, cfg); yamlErr == nil {
+		yamlErr := yaml.Unmarshal(raw, cfg)
+		if yamlErr == nil {
 			return nil
 		}
 
@@ -283,7 +286,8 @@ func (c *CLI) ExportConfigToFile(cfg *config.Config) error {
 		return eris.Errorf("unsupported file extension for config export: %s", ext)
 	}
 
-	if err = os.WriteFile(c.ExportConfig, data, 0o600); err != nil {
+	err = os.WriteFile(c.ExportConfig, data, 0o600)
+	if err != nil {
 		return eris.Wrapf(err, "failed to write config file: %s", c.ExportConfig)
 	}
 

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -145,13 +145,13 @@ func (c *CLI) ExportConfigToFile(cfg *config.Config) error {
 	case ".yaml", ".yml":
 		data, err = yaml.Marshal(cfg)
 		if err != nil {
-			return eris.Wrapf(err, "failed to marshal config as YAML")
+			return eris.Wrap(err, "failed to marshal config as YAML")
 		}
 
 	case ".json":
 		data, err = json.MarshalIndent(cfg, "", "  ")
 		if err != nil {
-			return eris.Wrapf(err, "failed to marshal config as JSON")
+			return eris.Wrap(err, "failed to marshal config as JSON")
 		}
 
 	default:

--- a/internal/dot/dot.go
+++ b/internal/dot/dot.go
@@ -40,13 +40,17 @@ func FindExecutable(dotPath string) (string, error) {
 // If a dot executable is found, its path is returned.
 func findInDirectory(directory string) (string, error) {
 	candidate := filepath.Join(directory, "dot")
-	if _, statErr := os.Stat(candidate); statErr == nil {
+
+	_, statErr := os.Stat(candidate)
+	if statErr == nil {
 		return candidate, nil
 	}
 
 	// Try with .exe extension on Windows
 	candidateExe := candidate + ".exe"
-	if _, statErr := os.Stat(candidateExe); statErr == nil {
+
+	_, statErr = os.Stat(candidateExe)
+	if statErr == nil {
 		return candidateExe, nil
 	}
 

--- a/internal/dot/dot_test.go
+++ b/internal/dot/dot_test.go
@@ -14,7 +14,8 @@ func TestFindExecutable_EmptyDotPath_FindsOnPath(t *testing.T) {
 
 	// This test requires dot to be available on PATH.
 	// If dot is not installed, we skip the test.
-	if _, err := findDotOnPath(); err != nil {
+	_, err := findDotOnPath()
+	if err != nil {
 		t.Skip("dot not found on PATH, skipping")
 	}
 
@@ -60,7 +61,8 @@ func TestFindExecutable_EmptyDotPathNoDot_ReturnsError(t *testing.T) {
 	g := NewWithT(t)
 
 	// If dot is already on PATH, we can't test this case.
-	if _, err := findDotOnPath(); err == nil {
+	_, err := findDotOnPath()
+	if err == nil {
 		t.Skip("dot is on PATH, cannot test missing dot")
 	}
 

--- a/internal/graphviz/graphviz.go
+++ b/internal/graphviz/graphviz.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"slices"
-	"sort"
 
 	"github.com/rotisserie/eris"
 
@@ -111,7 +110,7 @@ func writeGroupedNodesTo(
 		}
 	}
 
-	sort.Strings(topLevel)
+	slices.Sort(topLevel)
 
 	err := writeNodesTo(root, nsToNodes[""], cfg, reg)
 	if err != nil {
@@ -196,7 +195,7 @@ func childNamespaces(allNS map[string]bool, ns string) []string {
 		}
 	}
 
-	sort.Strings(children)
+	slices.Sort(children)
 
 	return children
 }

--- a/internal/graphviz/properties.go
+++ b/internal/graphviz/properties.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/theunrepentantgeek/task-graph/internal/indentwriter"
@@ -89,7 +88,7 @@ func (p properties) WriteTo(
 	nested := root.Addf("%s [", label)
 
 	keys := slices.Collect(maps.Keys(p))
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	for _, key := range keys {
 		value := p[key]

--- a/internal/graphviz/record.go
+++ b/internal/graphviz/record.go
@@ -30,8 +30,8 @@ func (r *record) String() string {
 	}
 
 	content := strings.Join(r.parts, " | ")
-	for s, r := range escapings {
-		content = strings.ReplaceAll(content, s, r)
+	for s, replacement := range escapings {
+		content = strings.ReplaceAll(content, s, replacement)
 	}
 
 	return fmt.Sprintf("{%s}", content)

--- a/internal/graphviz/record.go
+++ b/internal/graphviz/record.go
@@ -17,6 +17,26 @@ func newRecord() *record {
 	return &record{}
 }
 
+var escapings = map[string]string{
+	`{`: `\{`,
+	`}`: `\}`,
+	`"`: `\"`,
+}
+
+// String returns the string representation of the record, which is the parts joined by " | ".
+func (r *record) String() string {
+	if len(r.parts) == 1 {
+		return r.parts[0]
+	}
+
+	content := strings.Join(r.parts, " | ")
+	for s, r := range escapings {
+		content = strings.ReplaceAll(content, s, r)
+	}
+
+	return fmt.Sprintf("{%s}", content)
+}
+
 // add adds a part to the record.
 func (r *record) add(text string) {
 	if len(text) > 0 {
@@ -38,24 +58,4 @@ func (r *record) addWrapped(width int, text string) {
 // addWrappedf adds a formatted part to the record, wrapping the text to the specified width.
 func (r *record) addWrappedf(width int, format string, args ...any) {
 	r.addWrapped(width, fmt.Sprintf(format, args...))
-}
-
-var escapings = map[string]string{
-	`{`: `\{`,
-	`}`: `\}`,
-	`"`: `\"`,
-}
-
-// String returns the string representation of the record, which is the parts joined by " | ".
-func (r *record) String() string {
-	if len(r.parts) == 1 {
-		return r.parts[0]
-	}
-
-	content := strings.Join(r.parts, " | ")
-	for s, r := range escapings {
-		content = strings.ReplaceAll(content, s, r)
-	}
-
-	return fmt.Sprintf("{%s}", content)
 }

--- a/internal/indentwriter/indent_writer.go
+++ b/internal/indentwriter/indent_writer.go
@@ -25,7 +25,7 @@ func New() *IndentWriter {
 func (iw *IndentWriter) WriteTo(
 	w io.Writer,
 	indent string,
-) (n int64, err error) {
+) (int64, error) {
 	var bytesWritten int64
 
 	for _, line := range iw.lines {

--- a/internal/indentwriter/wrap.go
+++ b/internal/indentwriter/wrap.go
@@ -17,7 +17,6 @@ func WordWrap(text string, width int) []string {
 		return []string{text}
 	}
 
-	//nolint:prealloc // Number of lines is not easily predictable, so we don't preallocate the slice
 	var result []string
 
 	start := 0

--- a/internal/mermaid/mermaid.go
+++ b/internal/mermaid/mermaid.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/rotisserie/eris"
@@ -109,7 +108,7 @@ func writeGroupedNodesTo(
 		}
 	}
 
-	sort.Strings(topLevel)
+	slices.Sort(topLevel)
 
 	writeNodesTo(root, nsToNodes[""], reg)
 
@@ -159,7 +158,7 @@ func writeNamespaceSubgraphTo(
 		}
 	}
 
-	sort.Strings(children)
+	slices.Sort(children)
 
 	writeNodesTo(sg, nsToNodes[ns], reg)
 
@@ -265,7 +264,7 @@ func writeStyleRuleTo(
 	}
 
 	if len(matchingIDs) > 0 {
-		sort.Strings(matchingIDs)
+		slices.Sort(matchingIDs)
 		root.Addf("classDef rule%d %s", index, classDef)
 		root.Addf("class %s rule%d", strings.Join(matchingIDs, ","), index)
 	}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,8 @@ func main() {
 		ctx.Exit(1)
 	}
 
-	if err = cli.ExportConfigToFile(cfg); err != nil {
+	err = cli.ExportConfigToFile(cfg)
+	if err != nil {
 		log.Error("Error exporting config", "error", err)
 		ctx.Exit(1)
 	}


### PR DESCRIPTION
This pull request upgrades the project's `golangci-lint` version from `v2.6.2` to `v2.11.4` and adopts several new, high-value linters, improving code quality and consistency. The PR also includes codebase updates for compatibility with the new linter rules, minor refactors for clarity, and some code cleanup. A design doc is added to document the rationale and process for the linter upgrade.
