### PR TITLE
[Repo Assist] Add missing tests for config package and graph edge/node coverage

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestNew_GraphvizFont_ReturnsVerdana(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.Graphviz).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.Font).To(gomega.Equal("Verdana"))
+}
+
+func TestNew_GraphvizFontSize_Returns16(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.Graphviz).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.FontSize).To(gomega.Equal(16))
+}
+
+func TestNew_GraphvizDependencyEdges_ReturnsBlackSolidWidth1(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.Graphviz).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.DependencyEdges).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.DependencyEdges.Color).To(gomega.Equal("black"))
+	g.Expect(cfg.Graphviz.DependencyEdges.Style).To(gomega.Equal("solid"))
+	g.Expect(cfg.Graphviz.DependencyEdges.Width).To(gomega.Equal(1))
+}
+
+func TestNew_GraphvizCallEdges_ReturnsBlueDashedWidth1(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.Graphviz).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.CallEdges).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.CallEdges.Color).To(gomega.Equal("blue"))
+	g.Expect(cfg.Graphviz.CallEdges.Style).To(gomega.Equal("dashed"))
+	g.Expect(cfg.Graphviz.CallEdges.Width).To(gomega.Equal(1))
+}
+
+func TestNew_GraphvizTaskNodes_ReturnsBlackBorder(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.Graphviz).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.TaskNodes).NotTo(gomega.BeNil())
+	g.Expect(cfg.Graphviz.TaskNodes.Color).To(gomega.Equal("black"))
+}
+
+func TestNew_MermaidDirection_ReturnsTD(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.Mermaid).NotTo(gomega.BeNil())
+	g.Expect(cfg.Mermaid.Direction).To(gomega.Equal("TD"))
+}
+
+func TestNew_NodeStyleRules_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.NodeStyleRules).To(gomega.BeEmpty())
+}
+
+func TestNew_GroupByNamespace_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.GroupByNamespace).To(gomega.BeFalse())
+}
+
+func TestNew_AutoColor_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	cfg := New()
+
+	g.Expect(cfg.AutoColor).To(gomega.BeFalse())
+}
+
+func TestNodeStyleRule_Fields_RoundTrip(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	rule := NodeStyleRule{
+		Match:     "build*",
+		Color:     "red",
+		FillColor: "lightyellow",
+		Style:     "filled",
+		FontColor: "navy",
+	}
+
+	g.Expect(rule.Match).To(gomega.Equal("build*"))
+	g.Expect(rule.Color).To(gomega.Equal("red"))
+	g.Expect(rule.FillColor).To(gomega.Equal("lightyellow"))
+	g.Expect(rule.Style).To(gomega.Equal("filled"))
+	g.Expect(rule.FontColor).To(gomega.Equal("navy"))
+}

--- a/internal/graph/edge_test.go
+++ b/internal/graph/edge_test.go
@@ -25,3 +25,47 @@ func TestEdge_SetLabel_WithValue_UpdatesLabel(t *testing.T) {
 
 	g.Expect(edge.Label()).To(gomega.Equal("edge-label"))
 }
+
+func TestEdge_Class_GivenNewEdge_ReturnsEmptyString(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	edge := newEdge(NewNode("from"), NewNode("to"))
+
+	g.Expect(edge.Class()).To(gomega.Equal(""))
+}
+
+func TestEdge_SetClass_WithValue_UpdatesClass(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	edge := newEdge(NewNode("from"), NewNode("to"))
+
+	edge.SetClass("dependency")
+
+	g.Expect(edge.Class()).To(gomega.Equal("dependency"))
+}
+
+func TestEdge_From_ReturnsSourceNode(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	source := NewNode("source")
+	target := NewNode("target")
+
+	edge := newEdge(source, target)
+
+	g.Expect(edge.From()).To(gomega.BeIdenticalTo(source))
+}
+
+func TestEdge_To_ReturnsTargetNode(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	source := NewNode("source")
+	target := NewNode("target")
+
+	edge := newEdge(source, target)
+
+	g.Expect(edge.To()).To(gomega.BeIdenticalTo(target))
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -86,3 +86,40 @@ func TestGraph_Nodes_WithMultipleNodes_IteratesAllNodes(t *testing.T) {
 
 	g.Expect(ids).To(gomega.ConsistOf("alpha", "beta", "gamma"))
 }
+
+func TestGraph_Nodes_WithEarlyTermination_StopsIteration(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	graph := New()
+	graph.AddNode("alpha")
+	graph.AddNode("beta")
+	graph.AddNode("gamma")
+
+	var count int
+
+	graph.Nodes()(func(_ *Node) bool {
+		count++
+
+		return false // stop after first node
+	})
+
+	g.Expect(count).To(gomega.Equal(1))
+}
+
+func TestGraph_Nodes_EmptyGraph_IteratesNothing(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	graph := New()
+
+	var count int
+
+	graph.Nodes()(func(_ *Node) bool {
+		count++
+
+		return true
+	})
+
+	g.Expect(count).To(gomega.Equal(0))
+}

--- a/internal/graph/node_test.go
+++ b/internal/graph/node_test.go
@@ -29,3 +29,30 @@ func TestNode_AddEdge_ToTargetNode_AppendsEdge(t *testing.T) {
 	g.Expect(edge.From()).To(gomega.BeIdenticalTo(source))
 	g.Expect(edge.To()).To(gomega.BeIdenticalTo(target))
 }
+
+func TestNode_Edges_WithNoEdges_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	node := NewNode("alone")
+
+	g.Expect(node.Edges()).To(gomega.BeEmpty())
+}
+
+func TestNode_Edges_WithMultipleEdges_ReturnsAll(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	source := NewNode("source")
+	target1 := NewNode("target1")
+	target2 := NewNode("target2")
+
+	edge1 := source.AddEdge(target1)
+	edge2 := source.AddEdge(target2)
+
+	edges := source.Edges()
+
+	g.Expect(edges).To(gomega.HaveLen(2))
+	g.Expect(edges[0]).To(gomega.BeIdenticalTo(edge1))
+	g.Expect(edges[1]).To(gomega.BeIdenticalTo(edge2))
+}


### PR DESCRIPTION
- Add config_test.go with full coverage of Config.New() defaults, GraphvizNode, GraphvizEdge, Mermaid, and NodeStyleRule fields
- Add Edge.Class/SetClass tests to edge_test.go
- Add Edge.From/To tests to edge_test.go
- Add Node.Edges tests (empty and multiple) to node_test.go
- Add Graph.Nodes early-termination and empty-graph tests to graph_test.go