### PR TITLE
Add triggers for CI

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
   merge_group:
     branches:


### PR DESCRIPTION
This pull request makes a small update to the pull request validation workflow. It now triggers on additional pull request events, ensuring validation runs not just on new PRs, but also when PRs are updated, reopened, or marked as ready for review.